### PR TITLE
Some fixes and multiple gearmand server support

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,4 +14,4 @@ bin/naemon/statusengine-1-0-5.o: statusengine.c
 	LANG=C gcc -DNAEMON105 -shared -o "$@" -fPIC  -Wall -Werror statusengine.c -luuid -levent -lgearman -ljson-c -lglib-2.0 -I/usr/include/glib-2.0 -I/usr/lib/x86_64-linux-gnu/glib-2.0/include -lglib-2.0
 
 clean:
-	rm -f statusengine.o
+	rm -f bin/nagios/statusengine.o bin/naemon/statusengine.o bin/naemon/statusengine-1-0-5.o

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -191,8 +191,6 @@ extern char *global_service_event_handler;
 gearman_return_t ret; //remove me!!!
 gearman_client_st gman_client;
 
-gearman_client_st gman_client_ochp;
-
 void *statusengine_module_handle = NULL;
 
 int statusengine_handle_data(int, void *);
@@ -320,18 +318,6 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 		logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
 	}
 
-	if(enable_ochp || enable_ocsp){
-		//Create gearman client for ochp/ocsp
-		if (gearman_client_create(&gman_client_ochp) == NULL){
-			logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Memory allocation failure on client creation for OCHP/OCSP\n");
-		}
-
-		ret= gearman_client_add_server(&gman_client_ochp, gearman_server_addr, gearman_server_port);
-		if (ret != GEARMAN_SUCCESS){
-			logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client_ochp));
-		}
-	}
-
 	return 0;
 }
 
@@ -365,10 +351,6 @@ int nebmodule_deinit(int flags, int reason){
 
 	//Delete gearman client
 	gearman_client_free(&gman_client);
-
-	if(enable_ochp || enable_ocsp){
-		gearman_client_free(&gman_client_ochp);
-	}
 
 	return 0;
 }
@@ -857,9 +839,9 @@ int statusengine_handle_data(int event_type, void *data){
 					}
 
 					if(enable_ocsp){
-						ret= gearman_client_do_background(&gman_client_ochp, "statusngin_ocsp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
+						ret= gearman_client_do_background(&gman_client, "statusngin_ocsp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
 						if (ret != GEARMAN_SUCCESS)
-							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client_ochp));
+							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
 					}
 
 					json_object_put(servicecheck_object);
@@ -953,9 +935,9 @@ int statusengine_handle_data(int event_type, void *data){
 					}
 
 					if(enable_ochp){
-						ret= gearman_client_do_background(&gman_client_ochp, "statusngin_ochp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
+						ret= gearman_client_do_background(&gman_client, "statusngin_ochp", NULL, (void *)json_string, (size_t)strlen(json_string), NULL);
 						if (ret != GEARMAN_SUCCESS)
-							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client_ochp));
+							logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
 					}
 
 					json_object_put(hostcheck_object);

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -147,6 +147,8 @@
 
 //Load external libs
 #include <libgearman/gearman.h>
+#include <stdarg.h>
+#include <sys/time.h>
 
 #ifdef DEBIAN7
 #include <json/json.h>
@@ -157,8 +159,6 @@
 #if defined NAEMON105 || defined NAEMON
 #include <string.h>
 #endif
-
-#include <stdarg.h>
 
 // specify event broker API version (required)
 NEB_API_VERSION(CURRENT_NEB_API_VERSION);
@@ -188,7 +188,10 @@ extern sched_info scheduling_info;
 extern char *global_host_event_handler;
 extern char *global_service_event_handler;
 
+// gearman stuff
 gearman_client_st gman_client;
+int gman_connection_errors = 0;
+struct timeval gman_error_time;
 
 
 void *statusengine_module_handle = NULL;
@@ -286,16 +289,40 @@ int statusengine_create_client() {
 
 // send job to main gearman
 int statusengine_send_job(char * queue, char * data) {
+	struct timeval now;
+
 	// send job to gearman server
 	gearman_return_t ret = gearman_client_do_background(&gman_client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
 
 	// recreate client, otherwise gearman sigsegvs
 	if (ret != GEARMAN_SUCCESS) {
-		logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
+		gettimeofday(&now,NULL);
+
+		// log first errors
+		if (gman_connection_errors == 0) {
+			gettimeofday(&gman_error_time,NULL);
+			logswitch(NSLOG_INFO_MESSAGE, "sending to gearmand failed: %s\n", (char *)gearman_client_error(&gman_client));
+		}
+		// repeat connection error every minute
+		else if( now.tv_sec >= gman_error_time.tv_sec + 60) {
+			gettimeofday(&gman_error_time,NULL);
+			logswitch(NSLOG_INFO_MESSAGE, "sending to gearmand failed: %s (%i jobs lost so far)\n", (char *)gearman_client_error(&gman_client), gman_connection_errors);
+		}
+
+		gman_connection_errors++;
 		gearman_client_free(&gman_client);
 		statusengine_create_client();
 		return ERROR;
 	}
+
+	// log successful reconnect
+	if (gman_connection_errors > 0) {
+		logswitch(NSLOG_INFO_MESSAGE, "successfull reconnected to gearmand (%i lost jobs)\n", gman_connection_errors);
+	}
+
+	// reset if ok
+	gman_connection_errors = 0;
+
 	return OK;
 }
 

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -158,6 +158,8 @@
 #include <string.h>
 #endif
 
+#include <stdarg.h>
+
 // specify event broker API version (required)
 NEB_API_VERSION(CURRENT_NEB_API_VERSION);
 
@@ -195,12 +197,23 @@ int statusengine_handle_data(int, void *);
 void dump_object_data();
 
 
-void logswitch(int level, char *message){
+void logswitch(int level, char *message, ...){
+	char buffer[65536];
+	va_list ap;
+
+	// always prepend
+	snprintf(buffer, 15, "statusengine: ");
+
+	// easier logging with sprintf
+	va_start(ap, message);
+	vsnprintf( buffer + strlen( buffer ), sizeof( buffer ) - strlen( buffer ), message, ap );
+	va_end( ap );
+
 #ifdef NAGIOS
-	write_to_all_logs(message, level);
+	write_to_all_logs(buffer, level);
 #endif
 #if defined NAEMON || defined NAEMON105 || defined NAEMONMASTER
-	nm_log(level, "%s", message);
+	nm_log(level, "%s", buffer);
 #endif
 }
 
@@ -260,7 +273,7 @@ int statusengine_process_module_args(char *args);
 int statusengine_create_client() {
 	// Create gearman client
 	if (gearman_client_create(&gman_client) == NULL){
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Memory allocation failure on client creation\n");
+		logswitch(NSLOG_INFO_MESSAGE, "statusengine_create_client() Memory allocation failure on client creation\n");
 	}
 
 	gearman_return_t ret = gearman_client_add_server(&gman_client, gearman_server_addr, gearman_server_port);
@@ -301,20 +314,19 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 	neb_set_module_info(statusengine_module_handle, NEBMODULE_MODINFO_DESC,    "A powerful and flexible event broker");
 
 	//Welcome messages
-	logswitch(NSLOG_INFO_MESSAGE, "Statusengine - the missing event broker");
-	logswitch(NSLOG_INFO_MESSAGE, "Statusengine - the missing event broker");
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Copyright (c) 2014 - present Daniel Ziegler <daniel@statusengine.org>");
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Please visit https://www.statusengine.org for more information");
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Contribute to Statusenigne at: https://github.com/nook24/statusengine");
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Thanks for using Statusengine :-)");
+	logswitch(NSLOG_INFO_MESSAGE, "the missing event broker");
+	logswitch(NSLOG_INFO_MESSAGE, "Copyright (c) 2014 - present Daniel Ziegler <daniel@statusengine.org>");
+	logswitch(NSLOG_INFO_MESSAGE, "Please visit https://www.statusengine.org for more information");
+	logswitch(NSLOG_INFO_MESSAGE, "Contribute to Statusenigne at: https://github.com/nook24/statusengine");
+	logswitch(NSLOG_INFO_MESSAGE, "Thanks for using Statusengine :-)");
 
 	if (statusengine_process_module_args(args) == ERROR) {
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] An error occurred while attempting to process module arguments.");
+		logswitch(NSLOG_INFO_MESSAGE, "An error occurred while attempting to process module arguments.");
 		return ERROR;
 	}
 
 	//Register callbacks
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Register callbacks");
+	logswitch(NSLOG_INFO_MESSAGE, "Register callbacks");
 	neb_register_callback(NEBCALLBACK_HOST_STATUS_DATA,                 statusengine_module_handle, 0, statusengine_handle_data);
 	neb_register_callback(NEBCALLBACK_SERVICE_STATUS_DATA,              statusengine_module_handle, 0, statusengine_handle_data);
 	neb_register_callback(NEBCALLBACK_PROCESS_DATA,                     statusengine_module_handle, 0, statusengine_handle_data);
@@ -346,7 +358,7 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 int nebmodule_deinit(int flags, int reason){
 
 	// Deregister all callbacks
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Deregister callbacks");
+	logswitch(NSLOG_INFO_MESSAGE, "Deregister callbacks");
 	neb_deregister_callback(NEBCALLBACK_HOST_STATUS_DATA,                 statusengine_handle_data);
 	neb_deregister_callback(NEBCALLBACK_SERVICE_STATUS_DATA,              statusengine_handle_data);
 	neb_deregister_callback(NEBCALLBACK_PROCESS_DATA,                     statusengine_handle_data);
@@ -367,8 +379,8 @@ int nebmodule_deinit(int flags, int reason){
 	neb_deregister_callback(NEBCALLBACK_CONTACT_NOTIFICATION_METHOD_DATA, statusengine_handle_data);
 	neb_deregister_callback(NEBCALLBACK_EVENT_HANDLER_DATA,               statusengine_handle_data);
 
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] We are done here");
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Bye");
+	logswitch(NSLOG_INFO_MESSAGE, "We are done here");
+	logswitch(NSLOG_INFO_MESSAGE, "Bye");
 
 	//Delete gearman client
 	gearman_client_free(&gman_client);
@@ -409,82 +421,82 @@ int statusengine_process_config_var(char *arg) {
 	/* process the variable... */
 	if (!strcmp(var, "use_host_status_data")) {
 		use_host_status_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled host_status_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled host_status_data");
 	} else if (!strcmp(var, "use_service_status_data")) {
 		use_service_status_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled service_status_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled service_status_data");
 	} else if (!strcmp(var, "use_process_data")) {
 		use_process_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled process_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled process_data");
 	} else if (!strcmp(var, "use_service_check_data")) {
 		use_service_check_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled service_check_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled service_check_data");
 	} else if (!strcmp(var, "use_host_check_data")) {
 		use_host_check_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled host_check_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled host_check_data");
 	} else if (!strcmp(var, "use_state_change_data")) {
 		use_state_change_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled state_change_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled state_change_data");
 	} else if (!strcmp(var, "use_log_data")) {
 		use_log_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled log_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled log_data");
 	} else if (!strcmp(var, "use_system_command_data")) {
 		use_system_command_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled system_command_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled system_command_data");
 	} else if (!strcmp(var, "use_comment_data")) {
 		use_comment_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled comment_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled comment_data");
 	} else if (!strcmp(var, "use_external_command_data")) {
 		use_external_command_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled external_command_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled external_command_data");
 	} else if (!strcmp(var, "use_acknowledgement_data")) {
 		use_acknowledgement_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled acknowledgement_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled acknowledgement_data");
 	} else if (!strcmp(var, "use_flapping_data")) {
 		use_flapping_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled flapping_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled flapping_data");
 	} else if (!strcmp(var, "use_downtime_data")) {
 		use_downtime_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled downtime_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled downtime_data");
 	} else if (!strcmp(var, "use_notification_data")) {
 		use_notification_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled notification_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled notification_data");
 	} else if (!strcmp(var, "use_program_status_data")) {
 		use_program_status_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled program_status_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled program_status_data");
 	} else if (!strcmp(var, "use_contact_status_data")) {
 		use_contact_status_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled contact_status_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled contact_status_data");
 	} else if (!strcmp(var, "use_contact_notification_data")) {
 		use_contact_notification_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled contact_notification_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled contact_notification_data");
 	} else if (!strcmp(var, "use_contact_notification_method_data")) {
 		use_contact_notification_method_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled contact_notification_method_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled contact_notification_method_data");
 	} else if (!strcmp(var, "use_event_handler_data")) {
 		use_event_handler_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with disabled event_handler_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with disabled event_handler_data");
 	} else if (!strcmp(var, "enable_ochp")) {
 		enable_ochp = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with enabled enable_ochp");
+		logswitch(NSLOG_INFO_MESSAGE, "start with enabled enable_ochp");
 	} else if (!strcmp(var, "enable_ocsp")) {
 		enable_ocsp = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with enabled enable_ocsp");
+		logswitch(NSLOG_INFO_MESSAGE, "start with enabled enable_ocsp");
 	} else if (!strcmp(var, "use_object_data")) {
 		use_object_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with enabled use_object_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with enabled use_object_data");
 	} else if (!strcmp(var, "gearman_server_addr")) {
 		gearman_server_addr = strdup(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Gearman server address changed");
+		logswitch(NSLOG_INFO_MESSAGE, "Gearman server address changed: %s", val);
 	} else if (!strcmp(var, "gearman_server_port")) {
 		gearman_server_port = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Gearman server port changed");
+		logswitch(NSLOG_INFO_MESSAGE, "Gearman server port changed: %i", val);
 	} else if (!strcmp(var, "use_restart_data")) {
 		use_restart_data = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with enabled use_restart_data");
+		logswitch(NSLOG_INFO_MESSAGE, "start with enabled use_restart_data");
 	} else if (!strcmp(var, "use_service_perfdata")) {
 		use_service_perfdata = atoi(val);
-		logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] start with enabled use_service_perfdata");
+		logswitch(NSLOG_INFO_MESSAGE, "start with enabled use_service_perfdata");
 	} else {
 		return ERROR;
 	}
@@ -1547,7 +1559,7 @@ void dump_object_data(){
 
 	json_object_put(my_object);
 
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping command configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping command configuration");
 	for(temp_command = command_list; temp_command != NULL; temp_command = temp_command->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type", json_object_new_int(12));
@@ -1563,7 +1575,7 @@ void dump_object_data(){
 
 	//Fetch timeperiods
 	//Logging that we dump commands right now
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping timeperiod configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping timeperiod configuration");
 	for(temp_timeperiod = timeperiod_list; temp_timeperiod != NULL; temp_timeperiod = temp_timeperiod->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type", json_object_new_int(9));
@@ -1596,7 +1608,7 @@ void dump_object_data(){
 	}
 
 	//Fetch contact configuration
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping contact configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping contact configuration");
 	for(temp_contact = contact_list; temp_contact != NULL; temp_contact = temp_contact->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type",                    json_object_new_int(10));
@@ -1672,7 +1684,7 @@ void dump_object_data(){
 	}
 
 	//Fetch contact group configuration
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping contact group configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping contact group configuration");
 	for(temp_contactgroup = contactgroup_list; temp_contactgroup != NULL; temp_contactgroup = temp_contactgroup->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type",  json_object_new_int(11));
@@ -1695,7 +1707,7 @@ void dump_object_data(){
 	}
 
 	//Fetch host configuration
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping host configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping host configuration");
 	for(temp_host = host_list; temp_host != NULL; temp_host = temp_host->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type",  json_object_new_int(1));
@@ -1805,7 +1817,7 @@ void dump_object_data(){
 	}
 
 	//Fetch hostgroup configuration
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping host group configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping host group configuration");
 	for(temp_hostgroup = hostgroup_list; temp_hostgroup != NULL; temp_hostgroup=temp_hostgroup->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type",  json_object_new_int(3));
@@ -1834,7 +1846,7 @@ void dump_object_data(){
 
 
 	//Fetch service configuration
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping service configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping service configuration");
 	for(temp_service = service_list; temp_service != NULL; temp_service = temp_service->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type",  json_object_new_int(2));
@@ -1932,7 +1944,7 @@ void dump_object_data(){
 	}
 
 	//Fetch service groups
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping service group configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping service group configuration");
 	for(temp_servicegroup = servicegroup_list; temp_servicegroup != NULL; temp_servicegroup = temp_servicegroup->next){
 		my_object = json_object_new_object();
 		json_object_object_add(my_object, "object_type",  json_object_new_int(4));
@@ -1959,7 +1971,7 @@ void dump_object_data(){
 
 	#if defined NAEMON || defined NAGIOS
 	//Fetch host escalations
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping host escalation configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping host escalation configuration");
 	for(x = 0; x < num_objects.hostescalations; x++){
 		temp_hostescalation = hostescalation_ary[x];
 		my_object = json_object_new_object();
@@ -1998,7 +2010,7 @@ void dump_object_data(){
 	}
 
 	//Fetch service escalations
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping servcie escalation configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping servcie escalation configuration");
 	for(x = 0; x < num_objects.serviceescalations; x++) {
 		temp_serviceescalation = serviceescalation_ary[x];
 		my_object = json_object_new_object();
@@ -2038,7 +2050,7 @@ void dump_object_data(){
 		json_object_put(my_object);
 	}
 
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping host dependency configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping host dependency configuration");
 	for(x = 0; x < num_objects.hostdependencies; x++){
 		temp_hostdependency = hostdependency_ary[x];
 		my_object = json_object_new_object();
@@ -2060,7 +2072,7 @@ void dump_object_data(){
 		json_object_put(my_object);
 	}
 
-	logswitch(NSLOG_INFO_MESSAGE, "[Statusengine] Dumping service dependency configuration");
+	logswitch(NSLOG_INFO_MESSAGE, "Dumping service dependency configuration");
 	for(x = 0; x < num_objects.servicedependencies; x++){
 		temp_servicedependency = servicedependency_ary[x];
 		my_object = json_object_new_object();

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -385,6 +385,20 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 		return ERROR;
 	}
 
+	// add server if none has been defined
+	if (gearman_server_num == 0) {
+		char default_server[256];
+		sprintf(default_server, "%s:%i", gearman_server_addr, gearman_server_port);
+		statusengine_add_server(&gearman_server_num, gearman_server_list, default_server);
+	}
+
+	// create gearman clients
+	logswitch(NSLOG_INFO_MESSAGE, "create %i gearman client(s)\n", gearman_server_num);
+	int i;
+	for (i=0; i<gearman_server_num; i++) {
+		statusengine_create_client(i, gearman_server_list);
+	}
+
 	//Register callbacks
 	logswitch(NSLOG_INFO_MESSAGE, "Register callbacks");
 	neb_register_callback(NEBCALLBACK_HOST_STATUS_DATA,                 statusengine_module_handle, 0, statusengine_handle_data);
@@ -406,21 +420,6 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 	neb_register_callback(NEBCALLBACK_CONTACT_NOTIFICATION_DATA,        statusengine_module_handle, 0, statusengine_handle_data);
 	neb_register_callback(NEBCALLBACK_CONTACT_NOTIFICATION_METHOD_DATA, statusengine_module_handle, 0, statusengine_handle_data);
 	neb_register_callback(NEBCALLBACK_EVENT_HANDLER_DATA,               statusengine_module_handle, 0, statusengine_handle_data);
-
-
-	// add server if none has been defined
-	if (gearman_server_num == 0) {
-		char default_server[256];
-		sprintf(default_server, "%s:%d", gearman_server_addr, gearman_server_port);
-		statusengine_add_server(&gearman_server_num, gearman_server_list, default_server);
-	}
-
-	// create gearman clients
-	logswitch(NSLOG_INFO_MESSAGE, "create %i gearman client(s)\n", gearman_server_num);
-	int i;
-	for (i=0; i<gearman_server_num; i++) {
-		statusengine_create_client(i, gearman_server_list);
-	}
 
 	return 0;
 }

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -188,10 +188,23 @@ extern sched_info scheduling_info;
 extern char *global_host_event_handler;
 extern char *global_service_event_handler;
 
+// Structure of server object
+typedef struct gman_server {
+	char * server;
+	gearman_client_st * client;
+	int errors;
+	struct timeval error_time;
+} gman_server_t;
+
 // gearman stuff
+#define GMAN_MAX_SERVERS 16
 gearman_client_st gman_client;
 int gman_connection_errors = 0;
 struct timeval gman_error_time;
+gman_server_t * gearman_server_list[GMAN_MAX_SERVERS];
+int gearman_server_num = 0;
+char* gearman_server_addr = "127.0.0.1";
+int gearman_server_port = 4730;
 
 
 void *statusengine_module_handle = NULL;
@@ -266,64 +279,84 @@ int enable_ocsp = 0;
 int use_restart_data=1;
 int use_service_perfdata=0;
 
-char* gearman_server_addr = "127.0.0.1";
-int gearman_server_port = 4730;
-
 int statusengine_process_config_var(char *arg);
 int statusengine_process_module_args(char *args);
 
-// create main gearman client
-int statusengine_create_client() {
-	// Create gearman client
-	if (gearman_client_create(&gman_client) == NULL){
-		logswitch(NSLOG_INFO_MESSAGE, "statusengine_create_client() Memory allocation failure on client creation\n");
+// add server to list
+void statusengine_add_server(int * server_num, gman_server_t * server_list[GMAN_MAX_SERVERS], char * server) {
+	gman_server_t *new_server;
+	if (strcmp(server,"") != 0 && *server_num < GMAN_MAX_SERVERS) {
+		logswitch(NSLOG_INFO_MESSAGE, "add gearmand server[%i] %s\n", *server_num, server);
+		new_server = malloc(sizeof(gman_server_t));
+		new_server->server = strdup(server);
+		new_server->errors = 0;
+		new_server->client = malloc(sizeof(gearman_client_st));
+		server_list[*server_num] = new_server;
+		*server_num = *server_num + 1;
 	}
+	return;
+}
 
-	gearman_return_t ret = gearman_client_add_server(&gman_client, gearman_server_addr, gearman_server_port);
-	if (ret != GEARMAN_SUCCESS){
-		logswitch(NSLOG_INFO_MESSAGE, (char *)gearman_client_error(&gman_client));
+// create gearman client
+int statusengine_create_client(int i, gman_server_t * server_list[GMAN_MAX_SERVERS]) {
+	// check server number
+	if (i < 0 || i >= GMAN_MAX_SERVERS)
+                return ERROR;
+
+	// create client
+	if (gearman_client_create(server_list[i]->client) == NULL)
+		logswitch(NSLOG_INFO_MESSAGE, "Memory allocation failure on client creation\n");
+
+	// attach server
+	gearman_return_t ret = gearman_client_add_servers(server_list[i]->client, server_list[i]->server);
+	if (ret != GEARMAN_SUCCESS) {
+		logswitch(NSLOG_INFO_MESSAGE, "couldn't attach server %s to client: %s", server_list[i]->server, (char *)gearman_client_error(server_list[i]->client));
 		return ERROR;
 	}
 	return OK;
 }
 
-// send job to main gearman
+// send job to all gearmand servers
 int statusengine_send_job(char * queue, char * data) {
 	struct timeval now;
+	int final = OK;
 
-	// send job to gearman server
-	gearman_return_t ret = gearman_client_do_background(&gman_client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
+	// loop through all dup servers
+	int i;
+	for (i=0; i<gearman_server_num; i++) {
+		gearman_return_t ret = gearman_client_do_background(gearman_server_list[i]->client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
 
-	// recreate client, otherwise gearman sigsegvs
-	if (ret != GEARMAN_SUCCESS) {
-		gettimeofday(&now,NULL);
+		// recreate client on error
+		if (ret != GEARMAN_SUCCESS) {
+			gettimeofday(&now,NULL);
 
-		// log first errors
-		if (gman_connection_errors == 0) {
-			gettimeofday(&gman_error_time,NULL);
-			logswitch(NSLOG_INFO_MESSAGE, "sending to gearmand failed: %s\n", (char *)gearman_client_error(&gman_client));
+			// log first error
+			if (gearman_server_list[i]->errors == 0) {
+				gettimeofday(&gearman_server_list[i]->error_time,NULL);
+				logswitch(NSLOG_INFO_MESSAGE, "sending to gearmand %s failed: %s\n", gearman_server_list[i]->server, (char *)gearman_client_error(gearman_server_list[i]->client));
+			}
+			// repeat connection error every minute
+			else if( now.tv_sec >= gearman_server_list[i]->error_time.tv_sec + 60) {
+				gettimeofday(&gearman_server_list[i]->error_time,NULL);
+				logswitch(NSLOG_INFO_MESSAGE, "sending to gearmand %s failed: %s (%i jobs lost so far)\n", gearman_server_list[i]->server, (char *)gearman_client_error(gearman_server_list[i]->client), gearman_server_list[i]->errors);
+			}
+			// inc couter
+			gearman_server_list[i]->errors++;
+
+			// recreate client
+			gearman_client_free(gearman_server_list[i]->client);
+			statusengine_create_client(i, gearman_server_list);
+			final = ERROR;
+		} else {
+			// log successful reconnect
+			if (gearman_server_list[i]->errors > 0) {
+				logswitch(NSLOG_INFO_MESSAGE, "successfull reconnected to gearmand %s (%i lost jobs)\n", gearman_server_list[i]->server, gearman_server_list[i]->errors);
+			}
+			// reset if ok
+			gearman_server_list[i]->errors = 0;
 		}
-		// repeat connection error every minute
-		else if( now.tv_sec >= gman_error_time.tv_sec + 60) {
-			gettimeofday(&gman_error_time,NULL);
-			logswitch(NSLOG_INFO_MESSAGE, "sending to gearmand failed: %s (%i jobs lost so far)\n", (char *)gearman_client_error(&gman_client), gman_connection_errors);
-		}
-
-		gman_connection_errors++;
-		gearman_client_free(&gman_client);
-		statusengine_create_client();
-		return ERROR;
 	}
-
-	// log successful reconnect
-	if (gman_connection_errors > 0) {
-		logswitch(NSLOG_INFO_MESSAGE, "successfull reconnected to gearmand (%i lost jobs)\n", gman_connection_errors);
-	}
-
-	// reset if ok
-	gman_connection_errors = 0;
-
-	return OK;
+	return final;
 }
 
 //Broker initialize function
@@ -375,8 +408,19 @@ int nebmodule_init(int flags, char *args, nebmodule *handle){
 	neb_register_callback(NEBCALLBACK_EVENT_HANDLER_DATA,               statusengine_module_handle, 0, statusengine_handle_data);
 
 
-	//Create gearman client
-	statusengine_create_client();
+	// add server if none has been defined
+	if (gearman_server_num == 0) {
+		char default_server[256];
+		sprintf(default_server, "%s:%d", gearman_server_addr, gearman_server_port);
+		statusengine_add_server(&gearman_server_num, gearman_server_list, default_server);
+	}
+
+	// create gearman clients
+	logswitch(NSLOG_INFO_MESSAGE, "create %i gearman client(s)\n", gearman_server_num);
+	int i;
+	for (i=0; i<gearman_server_num; i++) {
+		statusengine_create_client(i, gearman_server_list);
+	}
 
 	return 0;
 }
@@ -409,8 +453,13 @@ int nebmodule_deinit(int flags, int reason){
 	logswitch(NSLOG_INFO_MESSAGE, "We are done here");
 	logswitch(NSLOG_INFO_MESSAGE, "Bye");
 
-	//Delete gearman client
-	gearman_client_free(&gman_client);
+	// cleanup
+	int i;
+        for (i=0; i<gearman_server_num; i++) {
+		gearman_client_free(gearman_server_list[i]->client);
+		free(gearman_server_list[i]);
+        }
+	gearman_server_num = 0;
 
 	return 0;
 }
@@ -518,6 +567,12 @@ int statusengine_process_config_var(char *arg) {
 	} else if (!strcmp(var, "gearman_server_port")) {
 		gearman_server_port = atoi(val);
 		logswitch(NSLOG_INFO_MESSAGE, "Gearman server port changed: %i", val);
+	} else if (!strcmp(var, "gearman_server_list")) {
+		logswitch(NSLOG_INFO_MESSAGE, "Gearman server address list changed: %s", val);
+		char *servername;
+		while ( (servername = strsep( &val, ";" )) != NULL ) {
+			statusengine_add_server(&gearman_server_num, gearman_server_list, servername);
+		}
 	} else if (!strcmp(var, "use_restart_data")) {
 		use_restart_data = atoi(val);
 		logswitch(NSLOG_INFO_MESSAGE, "start with enabled use_restart_data");

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -154,7 +154,7 @@
 #include <json-c/json.h>
 #endif
 
-#ifdef NAEMON
+#if defined NAEMON105 || defined NAEMON
 #include <string.h>
 #endif
 
@@ -186,10 +186,8 @@ extern sched_info scheduling_info;
 extern char *global_host_event_handler;
 extern char *global_service_event_handler;
 
-
-
-gearman_return_t ret; //remove me!!!
 gearman_client_st gman_client;
+
 
 void *statusengine_module_handle = NULL;
 
@@ -275,10 +273,8 @@ int statusengine_create_client() {
 
 // send job to main gearman
 int statusengine_send_job(char * queue, char * data) {
-	gearman_return_t ret = OK;
-
 	// send job to gearman server
-	ret = gearman_client_do_background(&gman_client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
+	gearman_return_t ret = gearman_client_do_background(&gman_client, queue, NULL, (void *)data, (size_t)strlen(data), NULL);
 
 	// recreate client, otherwise gearman sigsegvs
 	if (ret != GEARMAN_SUCCESS) {

--- a/src/statusengine.c
+++ b/src/statusengine.c
@@ -962,6 +962,7 @@ int statusengine_handle_data(int event_type, void *data){
 
 					json_object_put(servicecheck_object);
 					json_object_put(my_object);
+					free(raw_command);
 
 					if(use_service_perfdata){
 						my_object = json_object_new_object();
@@ -1050,6 +1051,7 @@ int statusengine_handle_data(int event_type, void *data){
 
 					json_object_put(hostcheck_object);
 					json_object_put(my_object);
+					free(raw_command);
 
 				}
 				break;


### PR DESCRIPTION
Fixes:
* If the gearmand server goes away (stop) and comes back online (start) the gearman_client doesn't crash. It doesn't segfault but it stops sending stuff to the queues
* This version recreates the gearman_client if an error occurs

Changes:
* the logswitch method accepts multiple arguments for sprintf like logging
* add_servers is now used instead of add_server: this way you can have failover gearmand server (comma seperated, not really useful but it works), but change the server port very easily
* the gearman_server_list option accepts multiple gearmand server (semicolon seperated) where the job needs to be duplicated. This very useful for satellite systems that report to multiple phpNSTA masters. if gearman_server_list is set, gearman_server_addr and gearman_server_port is ignored.
* connection errors to gearmand won't spam the naemon.log anymore. connection errors are repeated every minute

Example: Send duplicates to 2 gearmand:

    gearman_server_list=localhost:4730;localhost:4731

Example: have a failover gearmand:

    gearman_server_list=localhost:4731,localhost:4730

This also works combined (whatever):

    gearman_server_list=localhost:4731,localhost:4730;localhost:4733,localhost:4732
